### PR TITLE
Fix duplicated mapping key

### DIFF
--- a/streetcarts/specs/openapi/foodcarts.yaml
+++ b/streetcarts/specs/openapi/foodcarts.yaml
@@ -231,10 +231,10 @@ definitions:
       properties:
         cartname:
           type: string
+          description: Name of the food cart.
         uuid:
           type: string
           description: ID of the food cart.
-          description: Name of the food cart.
   foodcart:
     description: Food cart details.
     properties:


### PR DESCRIPTION
Duplicated mapping key causes parsing error in spec editor.  This file is used in https://docs-new.apigee.com/tutorial-publish-apis#import-spec.